### PR TITLE
Corrected UDP.h to Udp.h for case sensitive OSes

### DIFF
--- a/Arduino_SNMP.h
+++ b/Arduino_SNMP.h
@@ -11,7 +11,7 @@
 
 #define MIN(X, Y) ((X < Y) ? X : Y)
 
-#include <UDP.h>
+#include <Udp.h>
 
 #include "BER.h"
 #include "VarBinds.h"


### PR DESCRIPTION
changed <UDP.h> to <Udp.h> to respect case sensitive OSes such as Linux