### PR TITLE
Added new functions, modified argument types, fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a fully-compliant SNMPv2c Agent built for Arduino's, but will work on an
 * Complex data type support:
   * NETWORK ADDRESS
   * COUNTER32 `uint32_t`
-  * GUAGE32 `uint32_t`
+  * GAUGE32 `uint32_t`
   * TIMESTAMP `uint32_t`
   * OPAQUE `uint8_t*`
   * CONTER64 `uint64_t`

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SNMP_Agent
-version=2.0.3
+version=2.1.0
 author=Aidan Cyr <cyraidan@gmail.com>
 maintainer=Aidan Cyr <cyraidan@gmail.com>
 sentence=SNMP Agent: An fully compliant SNMPv2c Agent for esp32 for acting as an SNMP client device.

--- a/src/BERDecode.cpp
+++ b/src/BERDecode.cpp
@@ -237,8 +237,8 @@ std::shared_ptr<BER_CONTAINER> ComplexType::createObjectForType(ASN_TYPE valueTy
             return std::shared_ptr<BER_CONTAINER>(new TimestampType());
         case COUNTER32:
             return std::shared_ptr<BER_CONTAINER>(new Counter32());
-        case GUAGE32:
-            return std::shared_ptr<BER_CONTAINER>(new Guage());
+        case GAUGE32:
+            return std::shared_ptr<BER_CONTAINER>(new Gauge());
         case COUNTER64:
             return std::shared_ptr<BER_CONTAINER>(new Counter64());
         case OPAQUE:

--- a/src/SNMPPacket.cpp
+++ b/src/SNMPPacket.cpp
@@ -183,15 +183,15 @@ bool SNMPPacket::build(){
     return true;
 }
 
-void SNMPPacket::setCommunityString(std::string communityString){
+void SNMPPacket::setCommunityString(const std::string &CommunityString){
     // poison any cached containers we have
     this->communityStringPtr = nullptr;
-    this->communityString = communityString;
+    this->communityString = CommunityString;
 }
 
-void SNMPPacket::setRequestID(snmp_request_id_t requestID){
+void SNMPPacket::setRequestID(snmp_request_id_t RequestId){
     this->requestIDPtr = nullptr;
-    this->requestID = requestID;
+    this->requestID = RequestId;
 }
 
 bool SNMPPacket::setPDUType(ASN_TYPE responseType){
@@ -203,9 +203,9 @@ bool SNMPPacket::setPDUType(ASN_TYPE responseType){
     return false;
 }
 
-void SNMPPacket::setVersion(SNMP_VERSION snmpVersion){
+void SNMPPacket::setVersion(SNMP_VERSION SnmpVersion){
     this->snmpVersionPtr = nullptr;
-    this->snmpVersion = snmpVersion;
+    this->snmpVersion = SnmpVersion;
 }
 
 std::shared_ptr<ComplexType> SNMPPacket::generateVarBindList(){

--- a/src/SNMPParser.cpp
+++ b/src/SNMPParser.cpp
@@ -3,9 +3,9 @@
 
 static SNMP_PERMISSION getPermissionOfRequest(const SNMPPacket& request, const std::string& _community, const std::string& _readOnlyCommunity){
     SNMP_PERMISSION requestPermission = SNMP_PERM_NONE;
-    SNMP_LOGD("communitystring in packet: %s\n", request.communityString.c_str());
+    SNMP_LOGD("community string in packet: %s\n", request.communityString.c_str());
 
-    if(_readOnlyCommunity != "" && _readOnlyCommunity == request.communityString) { // snmprequest->version != 1
+    if(!_readOnlyCommunity.empty() && _readOnlyCommunity == request.communityString) { // snmprequest->version != 1
         requestPermission = SNMP_PERM_READ_ONLY;
     }
 

--- a/src/SNMPTrap.h
+++ b/src/SNMPTrap.h
@@ -43,7 +43,7 @@ class SNMPTrap : public SNMPPacket {
     short genericTrap = 6;
     short specificTrap = 1;
     
-    short _TrapUDPport = 162;
+    short trapUDPport = 162;
     
     bool inform = false;
 
@@ -78,7 +78,7 @@ class SNMPTrap : public SNMPPacket {
     }
     
     void setUDPport(short port){
-	_TrapUDPport = port;
+        trapUDPport = port;
     }
     
     void setUDP(UDP* udp){
@@ -137,7 +137,7 @@ class SNMPTrap : public SNMPPacket {
 
         if(length <= 0) return false;
 
-        _udp->beginPacket(ip, _TrapUDPport);
+        _udp->beginPacket(ip, trapUDPport);
         _udp->write(_packetBuffer, length);
         return _udp->endPacket();
     }

--- a/src/SNMP_Agent.h
+++ b/src/SNMP_Agent.h
@@ -44,38 +44,49 @@ class SNMPAgent {
             SNMPAgent::agents.push_back(this);
         }
 
-        void setReadOnlyCommunity(std::string community){
+        void setReadOnlyCommunity(const std::string& community){
             this->_readOnlyCommunity = community;
         }
 
-        void setReadWriteCommunity(std::string community){
+        void setReadWriteCommunity(const std::string& community){
             this->_community = community;
         }
 
         std::string _community = "public";
-        std::string _readOnlyCommunity = "";
+        std::string _readOnlyCommunity;
         
-        ValueCallback* addIntegerHandler(char* oid, int* value, bool isSettable = false, bool overwritePrefix = false);
-        ValueCallback* addReadWriteStringHandler(char* oid, char** value, size_t max_len = 0, bool isSettable = false, bool overwritePrefix = false);
-        ValueCallback* addReadOnlyStaticStringHandler(char* oid, std::string value, bool overwritePrefix = false);
-        ValueCallback* addOpaqueHandler(char* oid, uint8_t* value, size_t data_len, bool isSettable = false, bool overwritePrefix = false);
-        ValueCallback* addTimestampHandler(char* oid, uint32_t* value, bool isSettable = false, bool overwritePrefix = false);
-        ValueCallback* addOIDHandler(char* oid, std::string value, bool overwritePrefix = false);
-        ValueCallback* addCounter64Handler(char* oid, uint64_t* value, bool overwritePrefix = false);
-        ValueCallback* addCounter32Handler(char* oid, uint32_t* value, bool overwritePrefix = false);
-        ValueCallback* addGuageHandler(char* oid, uint32_t* value, bool overwritePrefix);
+        ValueCallback* addIntegerHandler(const char *oid, int* value, bool isSettable = false, bool overwritePrefix = false);
+        ValueCallback* addReadOnlyIntegerHandler(const char *oid, int value, bool overwritePrefix = false);
+        ValueCallback* addDynamicIntegerHandler(const char *oid, GETINT_FUNC callback_func, bool overwritePrefix = false);
+        ValueCallback* addReadWriteStringHandler(const char *oid, char** value, size_t max_len = 0, bool isSettable = false, bool overwritePrefix = false);
+        ValueCallback* addReadOnlyStaticStringHandler(const char *oid, const std::string& value, bool overwritePrefix = false);
+        ValueCallback* addDynamicReadOnlyStringHandler(const char *oid, GETSTRING_FUNC callback_func, bool overwritePrefix = false);
+        ValueCallback* addOpaqueHandler(const char *oid, uint8_t* value, size_t data_len, bool isSettable = false, bool overwritePrefix = false);
+        ValueCallback* addTimestampHandler(const char *oid, uint32_t* value, bool isSettable = false, bool overwritePrefix = false);
+        ValueCallback* addDynamicReadOnlyTimestampHandler(const char *oid, GETUINT_FUNC callback_func, bool overwritePrefix = false);
+        ValueCallback* addOIDHandler(const char *oid, const std::string& value, bool overwritePrefix = false);
+        ValueCallback* addCounter64Handler(const char *oid, uint64_t* value, bool overwritePrefix = false);
+        ValueCallback* addCounter32Handler(const char *oid, uint32_t* value, bool overwritePrefix = false);
+        ValueCallback* addGaugeHandler(const char *oid, uint32_t* value, bool overwritePrefix = false);
+        // Depreciated, use addGaugeHandler()
+        __attribute__((deprecated)) ValueCallback* addGuageHandler(const char *oid, uint32_t* value, bool overwritePrefix = false) {
+            return addGaugeHandler(oid, value, overwritePrefix);
+        }
 
-        bool setUDP(UDP* udp);
+        void
+        setUDP(UDP* udp);
         bool restartUDP();
 
-        bool begin();
-        bool begin(const char* oidPrefix);
+        void
+        begin();
+        void
+        begin(const char* oidPrefix);
         void stop();
-	enum SNMP_ERROR_RESPONSE loop();
+	    enum SNMP_ERROR_RESPONSE loop();
         
-        short _AgentUDPport = 161;
+        short AgentUDPport = 161;
         void setUDPport(short port){
-	        _AgentUDPport = port;
+	        AgentUDPport = port;
         }
         
         bool setOccurred = false;
@@ -101,7 +112,7 @@ class SNMPAgent {
         std::string oidPrefix;
         uint8_t _packetBuffer[MAX_SNMP_PACKET_LENGTH] = {0};
 
-        SortableOIDType* buildOIDWithPrefix(char* oid, bool overwritePrefix);
+        SortableOIDType* buildOIDWithPrefix(const char *oid, bool overwritePrefix);
 
         static std::list<SNMPAgent*> agents;
         std::list<struct InformItem*> informList;

--- a/src/ValueCallbacks.cpp
+++ b/src/ValueCallbacks.cpp
@@ -133,6 +133,7 @@ std::shared_ptr<BER_CONTAINER> ReadOnlyStringCallback::buildTypeWithValue(){
     return std::make_shared<OctetType>(this->value);
 }
 
+
 std::shared_ptr<BER_CONTAINER> OpaqueCallback::buildTypeWithValue(){
     ASSERT_VALID_VALUE(this->value);
 
@@ -172,17 +173,17 @@ SNMP_ERROR_STATUS Counter32Callback::setTypeWithValue(BER_CONTAINER* rawValue){
     return NO_ERROR;
 }
 
-std::shared_ptr<BER_CONTAINER> Guage32Callback::buildTypeWithValue(){
+std::shared_ptr<BER_CONTAINER> Gauge32Callback::buildTypeWithValue(){
     ASSERT_VALID_VALUE(this->value);
 
-    return std::make_shared<Guage>(*this->value);
+    return std::make_shared<Gauge>(*this->value);
 }
 
-SNMP_ERROR_STATUS Guage32Callback::setTypeWithValue(BER_CONTAINER* rawValue){
+SNMP_ERROR_STATUS Gauge32Callback::setTypeWithValue(BER_CONTAINER* rawValue){
     ASSERT_CALLBACK_SETTABLE();
     ASSERT_VALID_SETTABLE_VALUE(this->value);
 
-    Guage* val = static_cast<Guage*>(rawValue);
+    Gauge* val = static_cast<Gauge*>(rawValue);
     *this->value = val->_value;
 
     return NO_ERROR;
@@ -253,6 +254,6 @@ bool remove_handler(std::deque<ValueCallback*>& callbacks, ValueCallback* callba
         callbacks.erase(it);
         return true;
     } else {
-        return true;
+        return false;
     }
 }

--- a/src/include/BER.h
+++ b/src/include/BER.h
@@ -33,8 +33,8 @@ typedef enum ASN_TYPE_WITH_VALUE {
     STRUCTURE = 0x30,
     NETWORK_ADDRESS = 0x40,
     COUNTER32 = 0x41,
-    GUAGE32 = 0x42,
-    USIGNED32 = 0x42, // Same as Guage32
+    GAUGE32 = 0x42,
+    USIGNED32 = 0x42, // Same as Gauge32
     TIMESTAMP = 0x43,
     OPAQUE = 0x44,
 	COUNTER64 = 0x46,
@@ -66,20 +66,20 @@ typedef enum ASN_TYPE_WITH_VALUE {
 typedef int SNMP_BUFFER_PARSE_ERROR;
 typedef int SNMP_BUFFER_ENCODE_ERROR;
 
-#define SNMP_BUFFER_ERROR_MAX_LEN_EXCEEDED -1 + SNMP_BUFFER_PARSE_ERROR_OFFSET
-#define SNMP_BUFFER_ERROR_TLV_TOO_SMALL -2 + SNMP_BUFFER_PARSE_ERROR_OFFSET
-#define SNMP_BUFFER_ERROR_PROBLEM_DESERIALISING -3 + SNMP_BUFFER_PARSE_ERROR_OFFSET
-#define SNMP_BUFFER_ERROR_UNKNOWN_TYPE -4 + SNMP_BUFFER_PARSE_ERROR_OFFSET
-#define SNMP_BUFFER_ERROR_TYPE_MISMATCH -5 + SNMP_BUFFER_PARSE_ERROR_OFFSET
-#define SNMP_BUFFER_ERROR_OCTET_TOO_BIG -6 + SNMP_BUFFER_PARSE_ERROR_OFFSET
-#define SNMP_BUFFER_ERROR_INVALID_OID -7 + SNMP_BUFFER_PARSE_ERROR_OFFSET
+#define SNMP_BUFFER_ERROR_MAX_LEN_EXCEEDED (-1 + SNMP_BUFFER_PARSE_ERROR_OFFSET)
+#define SNMP_BUFFER_ERROR_TLV_TOO_SMALL (-2 + SNMP_BUFFER_PARSE_ERROR_OFFSET)
+#define SNMP_BUFFER_ERROR_PROBLEM_DESERIALISING (-3 + SNMP_BUFFER_PARSE_ERROR_OFFSET)
+#define SNMP_BUFFER_ERROR_UNKNOWN_TYPE (-4 + SNMP_BUFFER_PARSE_ERROR_OFFSET)
+#define SNMP_BUFFER_ERROR_TYPE_MISMATCH (-5 + SNMP_BUFFER_PARSE_ERROR_OFFSET)
+#define SNMP_BUFFER_ERROR_OCTET_TOO_BIG (-6 + SNMP_BUFFER_PARSE_ERROR_OFFSET)
+#define SNMP_BUFFER_ERROR_INVALID_OID (-7 + SNMP_BUFFER_PARSE_ERROR_OFFSET)
 
-#define SNMP_BUFFER_ENCODE_ERR_LEN_EXCEEDED -1 + SNMP_BUFFER_ENCODE_ERROR_OFFSET
-#define SNMP_BUFFER_ENCODE_ERROR_INVALID_ITEM -2 + SNMP_BUFFER_ENCODE_ERROR_OFFSET
-#define SNMP_BUFFER_ENCODE_ERROR_INVALID_OID -7 + SNMP_BUFFER_ENCODE_ERROR_OFFSET
+#define SNMP_BUFFER_ENCODE_ERR_LEN_EXCEEDED (-1 + SNMP_BUFFER_ENCODE_ERROR_OFFSET)
+#define SNMP_BUFFER_ENCODE_ERROR_INVALID_ITEM (-2 + SNMP_BUFFER_ENCODE_ERROR_OFFSET)
+#define SNMP_BUFFER_ENCODE_ERROR_INVALID_OID (-7 + SNMP_BUFFER_ENCODE_ERROR_OFFSET)
 
-#define CHECK_DECODE_ERR(i) if(i < 0) return i
-#define CHECK_ENCODE_ERR(i) if(i < 0) return i
+#define CHECK_DECODE_ERR(i) if((i) < 0) return i
+#define CHECK_ENCODE_ERR(i) if((i) < 0) return i
 
 // primitive types inherits straight off the container, complex come off complexType
 // all primitives have to serialiseInto themselves (type, length, data), to be put straight into the packet.
@@ -89,7 +89,7 @@ typedef int SNMP_BUFFER_ENCODE_ERROR;
 class BER_CONTAINER {
   public:
     BER_CONTAINER(ASN_TYPE type) : _type(type){};
-    virtual ~BER_CONTAINER(){};
+    virtual ~BER_CONTAINER()= default;
 
     ASN_TYPE _type;
     int _length = 0;
@@ -287,13 +287,13 @@ class Counter32: public IntegerType {
 
 };
 
-class Guage: public IntegerType { // Unsigned int
+class Gauge: public IntegerType { // Unsigned int
   public:
-    Guage(): IntegerType(){
-        _type = GUAGE32;
+    Gauge(): IntegerType(){
+        _type = GAUGE32;
     };
-    explicit Guage(unsigned int value): IntegerType(value){
-        _type = GUAGE32;
+    explicit Gauge(unsigned int value): IntegerType(value){
+        _type = GAUGE32;
     };
 
 };

--- a/src/include/SNMPPacket.h
+++ b/src/include/SNMPPacket.h
@@ -65,7 +65,7 @@ class SNMPPacket {
     int serialiseInto(uint8_t* buf, size_t max_len);
 
     //TODO: put checks in all these setters
-    void setCommunityString(std::string);
+    void setCommunityString(const std::string &CommunityString);
     void setRequestID(snmp_request_id_t);
     bool setPDUType(ASN_TYPE);
     void setVersion(SNMP_VERSION);

--- a/src/include/defs.h
+++ b/src/include/defs.h
@@ -80,19 +80,19 @@ typedef enum ERROR_STATUS_WITH_VALUE {
 
 #define SNMP_V1_MAX_ERROR GEN_ERR
 
-#define SNMP_ERROR_VERSION_CTRL(error, version) ((version == SNMP_VERSION_1 && error > SNMP_V1_MAX_ERROR) ? SNMP_V1_MAX_ERROR : error)
+#define SNMP_ERROR_VERSION_CTRL(error, version) (((version) == SNMP_VERSION_1 && (error) > SNMP_V1_MAX_ERROR) ? SNMP_V1_MAX_ERROR : (error))
 
 // Used for situations where in V2 an error exists but in V1 a less-specific error exists that isn't GEN_ERR
-#define SNMP_ERROR_VERSION_CTRL_DEF(error, version, elseError) ((version == SNMP_VERSION_1 && error > SNMP_V1_MAX_ERROR) ? SNMP_ERROR_VERSION_CTRL(elseError, version) : error)
+#define SNMP_ERROR_VERSION_CTRL_DEF(error, version, elseError) (((version) == SNMP_VERSION_1 && (error) > SNMP_V1_MAX_ERROR) ? SNMP_ERROR_VERSION_CTRL(elseError, version) : error)
 
 // RFC1213 OIDs
-#define RFC1213_OID_sysDescr            (char*)(".1.3.6.1.2.1.1.1.0")
-#define RFC1213_OID_sysObjectID         (char*)(".1.3.6.1.2.1.1.2.0")
-#define RFC1213_OID_sysUpTime           (char*)(".1.3.6.1.2.1.1.3.0")
-#define RFC1213_OID_sysContact          (char*)(".1.3.6.1.2.1.1.4.0")
-#define RFC1213_OID_sysName             (char*)(".1.3.6.1.2.1.1.5.0")
-#define RFC1213_OID_sysLocation         (char*)(".1.3.6.1.2.1.1.6.0")
-#define RFC1213_OID_sysServices         (char*)(".1.3.6.1.2.1.1.7.0")
+#define RFC1213_OID_sysDescr            (".1.3.6.1.2.1.1.1.0")
+#define RFC1213_OID_sysObjectID         (".1.3.6.1.2.1.1.2.0")
+#define RFC1213_OID_sysUpTime           (".1.3.6.1.2.1.1.3.0")
+#define RFC1213_OID_sysContact          (".1.3.6.1.2.1.1.4.0")
+#define RFC1213_OID_sysName             (".1.3.6.1.2.1.1.5.0")
+#define RFC1213_OID_sysLocation         (".1.3.6.1.2.1.1.6.0")
+#define RFC1213_OID_sysServices         (".1.3.6.1.2.1.1.7.0")
 
 typedef struct RFC1213SystemStruct {
         char*           sysDescr;               /* .1.3.6.1.2.1.1.1.0   Read-only   */


### PR DESCRIPTION
* `const char* oid` instead of `char* oid` as argument
*  use `const string&` instead of `string`
* New dynamic handlers that accepts function pointer as an argument:
  * `addDynamicIntegerHandler()`
  * `addDynamicReadOnlyTimestampHandler()`
  * `addDynamicReadOnlyStringHandler()`
 * Handler to accept `int` (not only `int*`)
 * Fixed typo in _guage_ to _gauge_ (as in spec). `addGugeHandler()` marked as depreciated (new function `addGaugeHandler()`).
 * minor fixes in variable names to satisfy clang-tidy
 * Version bumped to 2.1.0